### PR TITLE
contextmenu event opens more options menu

### DIFF
--- a/src/components/CardView.tsx
+++ b/src/components/CardView.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { Flex, Grid, Segment, Image, Text, gridBehavior, Ref } from '@stardust-ui/react';
+import { Grid, gridBehavior, Ref } from '@stardust-ui/react';
 import { IItemListProps } from './ListView';
 import { ICard } from '../api/api.interface';
-import { stripHTML, launchTaskModule } from '../utils/utils';
 import '../css/App.css';
-import { Overflow } from './Overflow';
-import { CustomImage } from './CustomImage';
-import { ThemeContext } from '../utils/themeContext';
+import { GridItem } from './GridItem';
 
 export const CardView: React.FC<IItemListProps> = (props: IItemListProps): JSX.Element => {
   // CONSTANTS
   const minimumCardWidth = 278; //px
-  const currentTheme = React.useContext(ThemeContext);
 
   // HELPER FUNCTION
   const calculateColumns = (width: number) => {
@@ -63,87 +59,7 @@ export const CardView: React.FC<IItemListProps> = (props: IItemListProps): JSX.E
 
   // ICARD PROCESSOR
   const processItem = (item: ICard): JSX.Element => {
-    return (
-      <Segment
-        data-is-focusable="true"
-        styles={{
-          margin: '0 0 16px 12px',
-          height: '146px',
-          padding: '20px 20px 20px 20px',
-          borderRadius: '3px',
-          boxShadow: '0px 2px 4px -0.75px rgba(0,0,0,0.1)',
-          position: 'relative',
-          border: `2px solid ${currentTheme.border}`,
-        }}
-        onClick={(): void => launchTaskModule(item)}
-        onKeyPress={(e: React.KeyboardEvent<HTMLDivElement>) => {
-          if (e.key === 'Enter') {
-            launchTaskModule(item);
-          }
-        }}
-      >
-        {item.content.actions ? (
-          <Overflow card={item} styles={{ position: 'absolute', right: '0', top: '0', margin: '0 8px 0px 0px' }} />
-        ) : null}
-        <Flex gap="gap.small">
-          <Flex.Item>
-            <CustomImage width="48px" className="listItemImage" src={item.preview.heroImageSrc} />
-          </Flex.Item>
-          <Flex.Item size="size.half" grow>
-            <Flex column styles={{ textAlign: 'left' }}>
-              <Flex.Item
-                styles={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 1, overflow: 'hidden' }}
-              >
-                <Text
-                  content={stripHTML(item.preview.title)}
-                  styles={{ margin: '0 0 2px 0' }}
-                  size="medium"
-                  weight="semibold"
-                  title={stripHTML(item.preview.title)}
-                />
-              </Flex.Item>
-              {item.preview.subTitle ? (
-                <Flex.Item
-                  styles={{
-                    display: '-webkit-box',
-                    WebkitBoxOrient: 'vertical',
-                    WebkitLineClamp: 1,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <Text
-                    content={stripHTML(item.preview.subTitle)}
-                    styles={{ margin: '0 0 2px 0' }}
-                    weight="regular"
-                    size="medium"
-                    title={stripHTML(item.preview.subTitle)}
-                  />
-                </Flex.Item>
-              ) : null}
-              {item.preview.text ? (
-                <Flex.Item
-                  grow
-                  size="size.half"
-                  styles={{
-                    display: '-webkit-box',
-                    WebkitBoxOrient: 'vertical',
-                    WebkitLineClamp: 3,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <Text
-                    content={stripHTML(item.preview.text)}
-                    weight="regular"
-                    size="medium"
-                    title={stripHTML(item.preview.text)}
-                  />
-                </Flex.Item>
-              ) : null}
-            </Flex>
-          </Flex.Item>
-        </Flex>
-      </Segment>
-    );
+    return <GridItem item={item}></GridItem>;
   };
 
   // RENDER

--- a/src/components/GridItem.tsx
+++ b/src/components/GridItem.tsx
@@ -22,11 +22,12 @@ export const GridItem: React.FC<IGridItemProps> = (props: IGridItemProps): JSX.E
     setMenuOpen(true);
   };
 
-  const handleLostFocus = (e: React.FocusEvent) => {
+  const onBlur = (e: React.FocusEvent) => {
     (e.currentTarget as HTMLElement).removeEventListener('contextmenu', handleContextMenu);
+    setMenuOpen(false);
   };
 
-  const handleOnFocus = (e: React.FocusEvent) => {
+  const onFocus = (e: React.FocusEvent) => {
     (e.currentTarget as HTMLElement).addEventListener('contextmenu', handleContextMenu);
   };
 
@@ -48,8 +49,8 @@ export const GridItem: React.FC<IGridItemProps> = (props: IGridItemProps): JSX.E
           launchTaskModule(props.item);
         }
       }}
-      onFocus={event => handleOnFocus(event)}
-      onBlur={event => handleLostFocus(event)}
+      onFocus={event => onFocus(event)}
+      onBlur={event => onBlur(event)}
     >
       {props.item.content.actions ? (
         <Overflow

--- a/src/components/GridItem.tsx
+++ b/src/components/GridItem.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Flex, Segment, Text, Ref } from '@stardust-ui/react';
+import { ICard } from '../api/api.interface';
+import { stripHTML, launchTaskModule } from '../utils/utils';
+import '../css/App.css';
+import { Overflow } from './Overflow';
+import { CustomImage } from './CustomImage';
+import { ThemeContext } from '../utils/themeContext';
+
+export interface IGridItemProps {
+  item: ICard;
+}
+
+export const GridItem: React.FC<IGridItemProps> = (props: IGridItemProps): JSX.Element => {
+  const currentTheme = React.useContext(ThemeContext);
+
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const handleContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).removeEventListener('contextmenu', handleContextMenu);
+    setMenuOpen(true);
+  };
+
+  const handleLostFocus = (e: React.FocusEvent) => {
+    (e.currentTarget as HTMLElement).removeEventListener('contextmenu', handleContextMenu);
+  };
+
+  const handleOnFocus = (e: React.FocusEvent) => {
+    (e.currentTarget as HTMLElement).addEventListener('contextmenu', handleContextMenu);
+  };
+
+  return (
+    <Segment
+      data-is-focusable="true"
+      styles={{
+        margin: '0 0 16px 12px',
+        height: '146px',
+        padding: '20px 20px 20px 20px',
+        borderRadius: '3px',
+        boxShadow: '0px 2px 4px -0.75px rgba(0,0,0,0.1)',
+        position: 'relative',
+        border: `2px solid ${currentTheme.border}`,
+      }}
+      onClick={(): void => launchTaskModule(props.item)}
+      onKeyPress={(e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter') {
+          launchTaskModule(props.item);
+        }
+      }}
+      onFocus={event => handleOnFocus(event)}
+      onBlur={event => handleLostFocus(event)}
+    >
+      {props.item.content.actions ? (
+        <Overflow
+          openMenu={menuOpen}
+          card={props.item}
+          styles={{ position: 'absolute', right: '0', top: '0', margin: '0 8px 0px 0px' }}
+        />
+      ) : null}
+      <Flex gap="gap.small">
+        <Flex.Item>
+          <CustomImage width="48px" className="listItemImage" src={props.item.preview.heroImageSrc} />
+        </Flex.Item>
+        <Flex.Item size="size.half" grow>
+          <Flex column styles={{ textAlign: 'left' }}>
+            <Flex.Item
+              styles={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 1, overflow: 'hidden' }}
+            >
+              <Text
+                content={stripHTML(props.item.preview.title)}
+                styles={{ margin: '0 0 2px 0' }}
+                size="medium"
+                weight="semibold"
+                title={stripHTML(props.item.preview.title)}
+              />
+            </Flex.Item>
+            {props.item.preview.subTitle ? (
+              <Flex.Item
+                styles={{
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 1,
+                  overflow: 'hidden',
+                }}
+              >
+                <Text
+                  content={stripHTML(props.item.preview.subTitle)}
+                  styles={{ margin: '0 0 2px 0' }}
+                  weight="regular"
+                  size="medium"
+                  title={stripHTML(props.item.preview.subTitle)}
+                />
+              </Flex.Item>
+            ) : null}
+            {props.item.preview.text ? (
+              <Flex.Item
+                grow
+                size="size.half"
+                styles={{
+                  display: '-webkit-box',
+                  WebkitBoxOrient: 'vertical',
+                  WebkitLineClamp: 3,
+                  overflow: 'hidden',
+                }}
+              >
+                <Text
+                  content={stripHTML(props.item.preview.text)}
+                  weight="regular"
+                  size="medium"
+                  title={stripHTML(props.item.preview.text)}
+                />
+              </Flex.Item>
+            ) : null}
+          </Flex>
+        </Flex.Item>
+      </Flex>
+    </Segment>
+  );
+};

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -14,6 +14,7 @@ export interface IProcessedItem {
   key: number;
   content: JSX.Element;
   onClick: () => void;
+  onFocus: (event: React.FocusEvent<Element>) => void;
 }
 
 export const ListView: React.FC<IItemListProps> = (props: IItemListProps): JSX.Element => {
@@ -46,6 +47,24 @@ export const ListView: React.FC<IItemListProps> = (props: IItemListProps): JSX.E
       }
     }
   });
+
+  const handleContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    const focusedElem = e.currentTarget as HTMLElement;
+    focusedElem.removeEventListener('contextmenu', handleContextMenu);
+    // Menu button contains the only a tag on a listitem
+    focusedElem.getElementsByTagName('a')[0].click();
+  };
+
+  const handleLostFocus = (e: FocusEvent) => {
+    (e.currentTarget as HTMLElement).removeEventListener('contextmenu', handleContextMenu);
+    (e.currentTarget as HTMLElement).removeEventListener('blur', handleLostFocus);
+  };
+
+  const itemOnFocus = (e: React.FocusEvent) => {
+    (e.currentTarget as HTMLElement).addEventListener('contextmenu', handleContextMenu);
+    (e.currentTarget as HTMLElement).addEventListener('blur', handleLostFocus);
+  };
 
   // Function to translate items from IPreviewCard to List.Item format
   const processItem = (item: ICard): IProcessedItem => {
@@ -90,13 +109,14 @@ export const ListView: React.FC<IItemListProps> = (props: IItemListProps): JSX.E
           ) : null}
           {item.content.actions ? (
             <Flex.Item shrink={0}>
-              <Overflow card={item} title="More Options" />
+              <Overflow card={item} title="More Options" openMenu={false} />
             </Flex.Item>
           ) : null}
         </Flex>
       ),
       styles: { margin: '2px 2px 0 0' },
       onClick: (): void => launchTaskModule(item),
+      onFocus: (event: React.FocusEvent<Element>): void => itemOnFocus(event),
     };
     return out;
   };

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -56,14 +56,14 @@ export const ListView: React.FC<IItemListProps> = (props: IItemListProps): JSX.E
     focusedElem.getElementsByTagName('a')[0].click();
   };
 
-  const handleLostFocus = (e: FocusEvent) => {
+  const onBlur = (e: FocusEvent) => {
     (e.currentTarget as HTMLElement).removeEventListener('contextmenu', handleContextMenu);
-    (e.currentTarget as HTMLElement).removeEventListener('blur', handleLostFocus);
+    (e.currentTarget as HTMLElement).removeEventListener('blur', onBlur);
   };
 
-  const itemOnFocus = (e: React.FocusEvent) => {
+  const onFocus = (e: React.FocusEvent) => {
     (e.currentTarget as HTMLElement).addEventListener('contextmenu', handleContextMenu);
-    (e.currentTarget as HTMLElement).addEventListener('blur', handleLostFocus);
+    (e.currentTarget as HTMLElement).addEventListener('blur', onBlur);
   };
 
   // Function to translate items from IPreviewCard to List.Item format
@@ -116,7 +116,7 @@ export const ListView: React.FC<IItemListProps> = (props: IItemListProps): JSX.E
       ),
       styles: { margin: '2px 2px 0 0' },
       onClick: (): void => launchTaskModule(item),
-      onFocus: (event: React.FocusEvent<Element>): void => itemOnFocus(event),
+      onFocus: (event: React.FocusEvent<Element>): void => onFocus(event),
     };
     return out;
   };

--- a/src/components/Overflow.tsx
+++ b/src/components/Overflow.tsx
@@ -7,10 +7,18 @@ export interface OverflowProps {
   card: ICard;
   styles?: object;
   title?: string;
+  openMenu: boolean;
 }
 
 export const Overflow: React.FC<OverflowProps> = (props: OverflowProps): JSX.Element => {
   const [menuOpen, setMenuOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    // If focus is true set focus to first element. Ignore otherwise
+    if (props.openMenu) {
+      setMenuOpen(true);
+    }
+  });
 
   const displayActions = (action: OverflowAction) => ({
     key: action.id,

--- a/src/components/Overflow.tsx
+++ b/src/components/Overflow.tsx
@@ -14,7 +14,6 @@ export const Overflow: React.FC<OverflowProps> = (props: OverflowProps): JSX.Ele
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   React.useEffect(() => {
-    // If focus is true set focus to first element. Ignore otherwise
     if (props.openMenu) {
       setMenuOpen(true);
     }


### PR DESCRIPTION
contextmenu event will open the more options menu when an item is focused on the list view and grid. While essentially the same solution the list view is not as elegant as the card view due to individual list items being generated in stardust and not having enough control. 